### PR TITLE
Croatian translation update

### DIFF
--- a/translations/hrv.po
+++ b/translations/hrv.po
@@ -44,7 +44,7 @@ msgstr "Igraj opet"
 
 # shared_strings.cpp
 msgid "Casual"
-msgstr ""
+msgstr "Klasično"
 
 # shared_strings.cpp
 msgid "Community levels"
@@ -68,11 +68,11 @@ msgstr "Službeni leveli"
 
 # shared_strings.cpp
 msgid "play count: %s"
-msgstr ""
+msgstr "broj igranja: %s"
 
 # shared_strings.cpp
 msgid "time played: %s"
-msgstr ""
+msgstr "vrijeme igranja: %s"
 
 # screen_download_level.cpp
 msgid "Downloading level..."
@@ -244,7 +244,7 @@ msgstr "Prijenos snimke za %s."
 
 # screen_career.cpp
 msgid "Statistics"
-msgstr ""
+msgstr "Statistika"
 
 # screen_configure_keyboard.cpp
 msgid "Configure keyboard"
@@ -476,7 +476,7 @@ msgstr "Svjetski rekord: %s"
 
 # screen_view_level.cpp
 msgid "average score: %s"
-msgstr ""
+msgstr "prosječni bodovi: %s"
 
 # screen_view_level.cpp
 msgid "by %s"
@@ -628,7 +628,7 @@ msgstr "Sve vaše medalje su ovdje."
 
 # screen_synchronize.cpp
 msgid "Failed to download backup data"
-msgstr ""
+msgstr "Neuspjelo preuzimanje podataka sigurnosne kopije"
 
 # screen_synchronize.cpp
 msgid "Failed to synchronize."
@@ -844,15 +844,15 @@ msgstr "Visoko"
 
 # renderer_types.cpp
 msgid "High (Dark)"
-msgstr ""
+msgstr "Visoko (Tamno)"
 
 # renderer_types.cpp
 msgid "Minimal"
-msgstr ""
+msgstr "Minimalno"
 
 # renderer_types.cpp
 msgid "Minimal (Dark)"
-msgstr ""
+msgstr "Minimalno (Tamno)"
 
 # renderer_types.cpp
 msgid "Ultra low 16x"
@@ -860,7 +860,7 @@ msgstr "Ultra nisko 16x"
 
 # renderer_types.cpp
 msgid "Ultra low 2x"
-msgstr ""
+msgstr "Ultra nisko 2x"
 
 # renderer_types.cpp
 msgid "Ultra low 32x"


### PR DESCRIPTION
In msgstr "Casual" I used the Croatian word for "Classic" instead because it's the best fitting word.