### PR TITLE
Croatian translation update

### DIFF
--- a/translations/hrv.po
+++ b/translations/hrv.po
@@ -248,7 +248,7 @@ msgstr "Statistika"
 
 # screen_select_level_of_author.cpp
 msgid "Levels by %s"
-msgstr "Level od %s"
+msgstr "Leveli od %s"
 
 # screen_configure_keyboard.cpp
 msgid "Configure keyboard"


### PR DESCRIPTION
Fixed a mistake.
"level od %s" -> "leveli od %s"